### PR TITLE
Test Rails 6.1 with Ruby 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
         include:
           - ruby: 3.2
             gemfile: gemfiles/activerecord71.gemfile
+          - ruby: 3.2
+            gemfile: gemfiles/activerecord61.gemfile
           - ruby: 3.1
             gemfile: Gemfile
           - ruby: "3.0"


### PR DESCRIPTION
The scope `scope :nearest_neighbors, ->(attribute_name, vector = nil, distance:) {` is breaking on Rails 6.1 with Ruby 3.2 with error:

`ArgumentError: wrong number of arguments (given 0, expected 1..2; required keyword: distance)`

This seems to be related to https://github.com/rails/rails/issues/46934.

I created this PR to test CI. Sorry for the notification.