### PR TITLE
Add support for Rails 6.1 with Ruby 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
         include:
           - ruby: 3.2
             gemfile: gemfiles/activerecord71.gemfile
+          - ruby: 3.2
+            gemfile: gemfiles/activerecord61.gemfile
           - ruby: 3.1
             gemfile: Gemfile
           - ruby: "3.0"

--- a/lib/neighbor/model.rb
+++ b/lib/neighbor/model.rb
@@ -26,7 +26,8 @@ module Neighbor
 
         return if @neighbor_attributes.size != 1
 
-        scope :nearest_neighbors, ->(attribute_name, vector = nil, distance:) {
+        scope :nearest_neighbors, ->(attribute_name, vector = nil, options) {
+          distance = options.fetch(:distance)
           if vector.nil? && !attribute_name.nil? && attribute_name.respond_to?(:to_a)
             vector = attribute_name
             attribute_name = :neighbor_vector


### PR DESCRIPTION
Scopes with keyword arguments are not supported by Rails 6.1 with Ruby 3.2. (see https://github.com/rails/rails/issues/46934)

In this PR, we update the scope `nearest_neighbors` so that it takes a hash of options instead of the keyword argument `distance`.

Without this change, calling the scope raises the following error on Rails 6.1 x Ruby 3.2:

```
The error is `ArgumentError: wrong number of arguments (given 3, expected 1..2; required keyword: distance)`.
```

([See on CI](https://github.com/retailzipline/neighbor/actions/runs/6224008816/job/16891230153))

This change should be transparent to most developers since the code to call the scope remains the same.