### PR TITLE
Use halfvec_l2_ops for halfvec HNSW index example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Index vectors at half precision for smaller indexes
 ```ruby
 class AddIndexToItemsEmbedding < ActiveRecord::Migration[8.0]
   def change
-    add_index :items, "(embedding::halfvec(3)) vector_l2_ops", using: :hnsw
+    add_index :items, "(embedding::halfvec(3)) halfvec_l2_ops", using: :hnsw
   end
 end
 ```


### PR DESCRIPTION
The “Half-Precision Indexing” example in the README currently shows:

```ruby
class AddIndexToItemsEmbedding < ActiveRecord::Migration[8.0]
  def change
    add_index :items, "(embedding::halfvec(3)) vector_l2_ops", using: :hnsw
  end
end
```

However, the vector_l2_ops operator class only works on full-precision vector columns, causing a PG::DatatypeMismatch when used on halfvec. 
This PR corrects the example to use the matching halfvec_l2_ops operator class.